### PR TITLE
added templated inline functions to determine the timestamp of a sample type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 rock_library(aggregator
-    SOURCES TimestampEstimator.cpp StreamAlignerStatus.cpp
+    SOURCES TimestampEstimator.cpp
+            StreamAlignerStatus.cpp
     DEPS_PKGCONFIG base-types base-lib
-    HEADERS TimestampEstimator.hpp TimestampEstimatorStatus.hpp
-    StreamAligner.hpp PullStreamAligner.hpp StreamAlignerStatus.hpp)
-    
+    HEADERS TimestampEstimator.hpp
+            TimestampEstimatorStatus.hpp
+            StreamAligner.hpp
+            PullStreamAligner.hpp
+            StreamAlignerStatus.hpp
+            DetermineSampleTimestamp.hpp)

--- a/src/DetermineSampleTimestamp.hpp
+++ b/src/DetermineSampleTimestamp.hpp
@@ -1,0 +1,45 @@
+#ifndef _AGGREGATOR_DETERMINE_SAMPLE_TIMESTAMP_HPP_
+#define _AGGREGATOR_DETERMINE_SAMPLE_TIMESTAMP_HPP_
+
+#include <base/Time.hpp>
+#include <boost/shared_ptr.hpp>
+#include <stdexcept>
+
+namespace aggregator
+{
+
+/**
+ * These methods are used to lookup the timestamp of a sample type.
+ * It is assumed that these types have a public field of type base::Time
+ * named time, which is the case for all base::samples::* types.
+ * For types where this assumption is not true, it is possible to specialized
+ * the method in the same namespace which provides a timestamp for this type.
+ * E.g.:
+ * namespace aggregator {
+ *      inline base::Time determineTimestamp(const some_namespace::SomeSampleType& type) {...}
+ * }
+ */
+
+template<typename T>
+inline base::Time determineTimestamp(const T& type)
+{
+    return type.time;
+}
+
+template<typename T>
+inline base::Time determineTimestamp(const T* type)
+{
+    if (type == NULL) throw std::invalid_argument("determineTimestamp: Received null pointer in function!");
+    return determineTimestamp(*type);
+}
+
+template<typename T>
+inline base::Time determineTimestamp(const boost::shared_ptr<T>& type)
+{
+    if (type.get() == NULL) throw std::invalid_argument("determineTimestamp: Received null pointer in function!");
+    return determineTimestamp(*type);
+}
+
+}
+
+#endif


### PR DESCRIPTION
This is a proposal to change the current lookup of timestamps in the stream aligner and transformer,
This would allow to specialize the function for a certain type in case it doesn't have a public field called time.

After looking into the orogen plugin of the aggregator, I encountered that at least for the stream aligner it is possible to define a different name for the time field. Since this is undocumented I guess it was rarely used, but I kept backward compatibility. If a field name is defined it will be used.

Another way would be to extend the possibility to set a time field name and a field type (e.g. base::Time, Microseconds, Seconds, ..) and make it also available to the transformer. Then it could also be used in case of the PCLPointcloud2. 
I think using the function approach is more flexible and needs less configurations, but it might be a bit more hidden 'magic'.
