### PR TITLE
Add boost dependency to cmakelists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,11 @@
+rock_find_cmake(Boost COMPONENTS system REQUIRED)
+
 rock_library(aggregator
     SOURCES TimestampEstimator.cpp
             StreamAlignerStatus.cpp
     DEPS_PKGCONFIG base-types base-lib
+    DEPS
+            Boost::system
     HEADERS TimestampEstimator.hpp
             TimestampEstimatorStatus.hpp
             StreamAligner.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,6 @@ rock_library(aggregator
     SOURCES TimestampEstimator.cpp
             StreamAlignerStatus.cpp
     DEPS_PKGCONFIG base-types base-lib
-    DEPS
-            Boost::system
     HEADERS TimestampEstimator.hpp
             TimestampEstimatorStatus.hpp
             StreamAligner.hpp


### PR DESCRIPTION
The library uses boost wich is found, as long as it is installed into the system path. On another configuration, it is required to find the boost include path via cmake, which is done by this merge request.