### PR TITLE
fix: use boost/circular_buffer.hpp directly

### DIFF
--- a/src/StreamAligner.hpp
+++ b/src/StreamAligner.hpp
@@ -5,7 +5,7 @@
 #include <cmath>
 #include <base-logging/Logging.hpp>
 #include <vector>
-#include <base/CircularBuffer.hpp>
+#include <boost/circular_buffer.hpp>
 #include <algorithm>
 #include <boost/function.hpp>
 #include <boost/tuple/tuple.hpp>

--- a/src/TimestampEstimator.hpp
+++ b/src/TimestampEstimator.hpp
@@ -2,7 +2,7 @@
 #define AGGREGATOR_TIMESTAMP_ESTIMATOR_HPP
 
 #include <base/Time.hpp>
-#include <base/CircularBuffer.hpp>
+#include <boost/circular_buffer.hpp>
 #include <vector>
 
 #include <aggregator/TimestampEstimatorStatus.hpp>


### PR DESCRIPTION
The reason of CircularBuffer's existence disappeared in Boost 1.62 (cerca 2016)